### PR TITLE
Add a quickstart example for Maven SWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# JxBrowser-QuickStart-Maven-SWT
+# JxBrowser in SWT Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to embed an SWT `BrowserView` widget into an SWT desktop application to display web pages.
+
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart-Maven-SWT.git
+ cd JxBrowser-QuickStart-Maven-SWT
+ ```
+
+## Get License
+
+Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the SWT Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start an SWT desktop application with SWT `BrowserView` inside that displays https://html5test.teamdev.com as shown below:
+
+![SWT BrowserView](https://jxbrowser-support.teamdev.com/img/articles/swt-view.png)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.teamdev.jxbrowser.quickstart.maven</groupId>
+    <artifactId>swt</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <jxbrowser.version>8.1.0</jxbrowser.version>
+        <swt.version>4.3</swt.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloSWT</exec.mainClass>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>com.teamdev</id>
+            <url>https://europe-maven.pkg.dev/jxbrowser/releases</url>
+        </repository>
+        <repository>
+            <id>maven-eclipse-repo</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.teamdev.jxbrowser</groupId>
+            <artifactId>jxbrowser-cross-platform</artifactId>
+            <version>${jxbrowser.version}</version>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.teamdev.jxbrowser</groupId>
+            <artifactId>jxbrowser-swt</artifactId>
+            <version>${jxbrowser.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.swt</groupId>
+            <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
+            <version>${swt.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.swt</groupId>
+            <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
+            <version>${swt.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.swt</groupId>
+            <artifactId>org.eclipse.swt.cocoa.macosx.x86_64</artifactId>
+            <version>${swt.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/HelloSWT.java
+++ b/src/main/java/HelloSWT.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
+
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.view.swt.BrowserView;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * This example demonstrates how to initialize Chromium, create a browser instance
+ * (equivalent of the Chromium tab), embed an SWT BrowserView widget into SWT
+ * shell to display content of the loaded web page, load the required web page.
+ */
+public final class HelloSWT {
+
+    public static void main(String[] args) {
+        // Initialize Chromium.
+        Engine engine = Engine.newInstance(HARDWARE_ACCELERATED);
+
+        // Create a Browser instance.
+        Browser browser = engine.newBrowser();
+
+        // Load the required web page.
+        browser.navigation().loadUrl("https://html5test.teamdev.com");
+
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setText("JxBrowser SWT");
+        shell.setLayout(new FillLayout());
+
+        // Create and embed SWT BrowserView widget to display web content.
+        BrowserView view = BrowserView.newInstance(shell, browser);
+        view.setSize(1280, 800);
+
+        shell.pack();
+        shell.open();
+
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch()) {
+                display.sleep();
+            }
+        }
+        // Shutdown Chromium and release allocated resources.
+        engine.close();
+
+        display.dispose();
+    }
+}


### PR DESCRIPTION
This changeset adds a quickstart example for Maven SWT.

Issue: TeamDev-IP/JxBrowser/issues/4066